### PR TITLE
Added brew relinking

### DIFF
--- a/macdeployqtfix.py
+++ b/macdeployqtfix.py
@@ -17,7 +17,7 @@ BREWLIB_REGEX = r'^/usr/local/.*/(.*)'
 QTLIB_NORMALIZED = r'$prefix/Frameworks/$qtlib.framework/Versions/$qtversion/$qtlib'
 QTPLUGIN_NORMALIZED = r'$prefix/PlugIns/$plugintype/$pluginname.dylib'
 
-BREWLIB_NORMALIZED = r'$prefix/'
+BREWLIB_NORMALIZED = r'$prefix/Frameworks/$brewlib'
 
 
 class GlobalConfig:
@@ -207,6 +207,7 @@ def normalize_brew_name(filename):
         brewlib=brewlib)
 
     GlobalConfig.logger.debug('\treturns({0})'.format((brewlib, abspath, rpath)))
+    print filename, "->",brewlib, abspath, rpath
     return brewlib, abspath, rpath
 
     

--- a/macdeployqtfix.py
+++ b/macdeployqtfix.py
@@ -191,22 +191,20 @@ def normalize_brew_name(filename):
         msg = 'couldn\'t normalize a brew lib filename: {0}'.format(filename)
         GlobalConfig.logger.critical(msg)
         raise Exception(msg)
-# 
-#     # brewlib normalization settings
+
+    # brewlib normalization settings
     brewlib = rgxret.groups()[0]
-# 
     templ = Template(BREWLIB_NORMALIZED)
-#     # from brewlib, forge 2 path :
-#     #  - absolute path of qt lib in bundle,
+    # from brewlib, forge 2 path :
+    #  - absolute path of qt lib in bundle,
     abspath = os.path.normpath(templ.safe_substitute(
         prefix=os.path.dirname(GlobalConfig.exepath) + '/..',
         brewlib=brewlib))
         
-#     #  - and rpath containing @executable_path, relative to exepath
+    #  - and rpath containing @executable_path, relative to exepath
     rpath = templ.safe_substitute(
         prefix='@executable_path/..',
         brewlib=brewlib)
-    print filename, " -> ", brewlib, abspath, rpath
 
     GlobalConfig.logger.debug('\treturns({0})'.format((brewlib, abspath, rpath)))
     return brewlib, abspath, rpath

--- a/macdeployqtfix.py
+++ b/macdeployqtfix.py
@@ -11,8 +11,13 @@ from collections import namedtuple
 
 QTLIB_NAME_REGEX = r'^(?:@executable_path)?/.*/(Qt[a-zA-Z]*).framework/(?:Versions/\d/)?\1$'
 QTPLUGIN_NAME_REGEX = r'^(?:@executable_path)?/.*/[pP]lug[iI]ns/(.*)/(.*).dylib$'
+
+BREWLIB_REGEX = r'^/usr/local/.*/(.*)'
+
 QTLIB_NORMALIZED = r'$prefix/Frameworks/$qtlib.framework/Versions/$qtversion/$qtlib'
 QTPLUGIN_NORMALIZED = r'$prefix/PlugIns/$plugintype/$pluginname.dylib'
+
+BREWLIB_NORMALIZED = r'$prefix/'
 
 
 class GlobalConfig:
@@ -74,6 +79,15 @@ def is_qt_lib(filename):
     accept absolute path as well as path containing @executable_path
     """
     qtlib_name_rgx = re.compile(QTLIB_NAME_REGEX)
+    rgxret = qtlib_name_rgx.match(filename)
+    return rgxret is not None
+
+def is_brew_lib(filename):
+    """
+    check if a given file is a brew library
+    accept absolute path as well as path containing @executable_path
+    """
+    qtlib_name_rgx = re.compile(BREWLIB_REGEX)
     rgxret = qtlib_name_rgx.match(filename)
     return rgxret is not None
 
@@ -158,14 +172,58 @@ def normalize_qtlib_name(filename):
     GlobalConfig.logger.debug('\treturns({0})'.format((qtlib, abspath, rpath)))
     return qtlib, abspath, rpath
 
+
+def normalize_brew_name(filename):
+    """
+    input: a path to a brew library, as returned by otool, that can have this form :
+            - an absolute path /usr/local/lib/yyy
+    output:
+        a tuple (brewlib, abspath, rpath) where:
+            - brewlib is the name of the brew lib
+            - abspath is the absolute path of the qt lib inside the app bundle of exepath
+            - relpath is the correct rpath to a qt lib inside the app bundle
+    """
+    GlobalConfig.logger.debug('normalize_brew_name({0})'.format(filename))
+ 
+    brewlib_name_rgx = re.compile(BREWLIB_REGEX)
+    rgxret = brewlib_name_rgx.match(filename)
+    if not rgxret:
+        msg = 'couldn\'t normalize a brew lib filename: {0}'.format(filename)
+        GlobalConfig.logger.critical(msg)
+        raise Exception(msg)
+# 
+#     # brewlib normalization settings
+    brewlib = rgxret.groups()[0]
+# 
+    templ = Template(BREWLIB_NORMALIZED)
+#     # from brewlib, forge 2 path :
+#     #  - absolute path of qt lib in bundle,
+    abspath = os.path.normpath(templ.safe_substitute(
+        prefix=os.path.dirname(GlobalConfig.exepath) + '/..',
+        brewlib=brewlib))
+        
+#     #  - and rpath containing @executable_path, relative to exepath
+    rpath = templ.safe_substitute(
+        prefix='@executable_path/..',
+        brewlib=brewlib)
+    print filename, " -> ", brewlib, abspath, rpath
+
+    GlobalConfig.logger.debug('\treturns({0})'.format((brewlib, abspath, rpath)))
+    return brewlib, abspath, rpath
+
+    
 def fix_dependency(binary, dep):
     """
     fix 'dep' dependency of 'binary'. 'dep' is a qt library
     """
+    
+    
     if is_qt_lib(dep):
         qtname, dep_abspath, dep_rpath = normalize_qtlib_name(dep)
     elif is_qt_plugin(dep):
         qtname, dep_abspath, dep_rpath = normalize_qtplugin_name(dep)
+    elif is_brew_lib(dep):
+        qtname, dep_abspath, dep_rpath = normalize_brew_name(dep)
     else:
         return True
 


### PR DESCRIPTION
I've found that not only `macdeployqt` didn't fix the relinking of QT, but wasn't relinking some library that I used from Brew.

For example I link `fftw` (`libfftw3.3.dylib`) which is copied in the `Frameworks` of the bundle but was itself still linking to the brew path `/usr/local/lib/gcc/6/libgcc_s.1.dylib` 

I had a total of 12 libs like these which I had to manually relink using `install_name_tool`

So I added this for the brew libraries which are located in `/usr/local`. To do this I added 
two regex: `BREWLIB_REGEX` and a  `BREWLIB_NORMALIZED` plus the 2 functions `is_brew_lib` called only if it's not a Qt lib or plugin and `normalize_brew_name` to relink.

I found that this fixes all my problems and hoe it help someone else.
