### PR TITLE
Add super basic travis ci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+sudo: false
+
+script:
+- python2 macdeployqtfix.py --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+os: osx
 
 script:
 - python2 macdeployqtfix.py --help


### PR DESCRIPTION
The travis-ci script just runs `macdeployqtfix.py  --help` in order to check for typos, import errors, etc; at least to prevent issues like #8 
In the future, #7 will include a more exhaustive test suite